### PR TITLE
add request object to authorizer params

### DIFF
--- a/src/action.coffee
+++ b/src/action.coffee
@@ -53,7 +53,7 @@ module.exports = class Action
       schemes = [schemes]
 
     if schemes? && context.authorizer?
-      result = context.authorizer(schemes, resource, @name)
+      result = context.authorizer(schemes, resource, @name, request)
       if result?
         {scheme, credential} = result
         request.headers["Authorization"] = "#{scheme} #{credential}"

--- a/src/action.coffee
+++ b/src/action.coffee
@@ -52,7 +52,7 @@ module.exports = class Action
       schemes = [schemes]
 
     if schemes? && @client.context.authorizer?
-      result = @client.context.authorizer(schemes, resource, @name)
+      result = @client.context.authorizer(schemes, resource, @name, request)
       if result?
         {scheme, credential} = result
         request.headers["Authorization"] = "#{scheme} #{credential}"

--- a/src/action.coffee
+++ b/src/action.coffee
@@ -54,7 +54,6 @@ module.exports = class Action
 
     if schemes? && context.authorizer?
       result = context.authorizer(schemes, resource, @name)
-
       if result?
         {scheme, credential} = result
         request.headers["Authorization"] = "#{scheme} #{credential}"


### PR DESCRIPTION
Following suit of what was done in Patchboard.py. 

Allows request body to be encrypted for authorization.