### PR TITLE
update generate_url so it encodes url safe charchters

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -128,10 +128,10 @@ API.Mapping = class Mapping
       for key in keys
         schema = query[key]
         if (string = params[key])?
-          parts.push "#{key}=#{string}"
+          parts.push "#{encodeURIComponent(key)}=#{encodeURIComponent(string)}"
       if parts.length > 0
         query_string = "?#{parts.join('&')}"
       else
         query_string = ""
 
-    encodeURI(url + path + query_string)
+    encodeURI(url + path) + query_string


### PR DESCRIPTION
We were running into issues when a user created an account with an email that included "+". The problem was that the email was being encoded with encodeURI which does not return url-safe characters:

``` encodeURI("+") == "+" ```

Now every part of the query is being encoded with encodeURIComponent, which will encode "+"

``` encodeURIComponent("+") == "%2B" ```

The new code follows Patcboard.py's implementation, which is working fine for us: https://github.com/patchboard/patchboard-py/blob/master/patchboard/mapping.py#L63-L66

